### PR TITLE
fix expose in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ USER squid
 RUN echo squid -v
 
 # TODO: Set the default port for applications built using this image
-EXPOSE 3128/tcp
+EXPOSE 3128
 
 VOLUME ["${SQUID_CACHE_DIR}"]
 


### PR DESCRIPTION
Under Openshift 3, Docker 1.12.6, docker build fails with error on EXPOSE (/tcp).  Removing the protocol builds without error.  It would seem the syntax has changed but TCP is default?